### PR TITLE
Cannot read property 'query' of undefined

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -1,4 +1,8 @@
 function sendMessageToActiveTab(message, callback) {
+  // if not available
+  if(!chrome.tabs) {
+    return;
+  }
   chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
     tab = tabs[0];
     chrome.tabs.sendMessage(tab.id, message, callback);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,7 +15,7 @@
     "default_icon": "icon.png",
     "default_popup": "controls.html"
   },
-  "permissions": ["activeTab"],
+  "permissions": ["activeTab", "tabs"],
   "content_scripts": [
     {
       "matches": ["*://*/*"],


### PR DESCRIPTION
* Give extension tabs permission
* Defensive program against its unavailability

Fixes: #1

(I'm not sure if you are still maintaining and releasing this extension but this error looked straightforward to fix and is likely showing up in many site owners error logs including Wikipedia)